### PR TITLE
Fix SCOPED_OBJECT_DATA_CAPTURE for debug targets

### DIFF
--- a/Source/WaterPhysics/Private/WaterPhysicsDebug/WaterPhysicsDataProfiler.h
+++ b/Source/WaterPhysics/Private/WaterPhysicsDebug/WaterPhysicsDataProfiler.h
@@ -34,7 +34,7 @@ namespace WaterPhysicsDebug
 
 #define RUN_CAPTURE_FUNC(Expression) if (WaterPhysicsDebug::CurrentSessionWriter != nullptr) { Expression; }
 
-#define SCOPED_OBJECT_DATA_CAPTURE(ObjectName, Category, ...) WaterPhysicsDebug::FScopedEventData PREPROCESSOR_JOIN(ScopedWaterPhysicsEventData, __LINE__)(ObjectName, Category, __VA_ARGS__)
+#define SCOPED_OBJECT_DATA_CAPTURE(ObjectName, Category, ...) WaterPhysicsDebug::FScopedEventData PREPROCESSOR_JOIN(ScopedWaterPhysicsEventData, __LINE__)(ObjectName, Category, ##__VA_ARGS__)
 #define DEBUG_CAPTURE_STRING(Name, Value) RUN_CAPTURE_FUNC(WaterPhysicsDebug::CaptureString(Name, Value))
 #define DEBUG_CAPTURE_NUMBER(Name, Value) RUN_CAPTURE_FUNC(WaterPhysicsDebug::CaptureNumber(Name, Value))
 #define DEBUG_CAPTURE_USTRUCT(Name, Value) RUN_CAPTURE_FUNC(WaterPhysicsDebug::CaptureStruct(Name, TRemoveReference<decltype(Value)>::Type::StaticStruct(), (void*)&Value))


### PR DESCRIPTION
When I tried to compile for the DebugGame target, I would get the error:
Error C2059 : syntax error: ')' on the SCOPED_OBJECT_DATA_CAPTURE macro

This is because the WaterPhysicsDebug::FScopedEventData constructor has a default/optional InScale parameter which is not added in a number of uses of the macro.
                                                                                                                                                                            ⌄
WaterPhysicsDebug::FScopedEventData ScopedWaterPhysicsEventData123(MyObjectName, "MyCategory",     );

The fix is to make the comma preceding ```__VA_ARGS__``` conditional via the ## operator.